### PR TITLE
Feature -> Develop | Added: UTC to local method

### DIFF
--- a/skeletons/vaahcms/module-primevue4/Vue/vaahvue/pinia/vaah.js
+++ b/skeletons/vaahcms/module-primevue4/Vue/vaahvue/pinia/vaah.js
@@ -477,6 +477,11 @@ export const vaah = defineStore({
 
     },
     //----------------------------------------------------------
+    convertUtcToLocal: function (utc, format='YYYY-MM-DD, hh:mm A') {
+      if (!utc) return '';
+      const local_date = dayjs.utc(utc).local();
+      return local_date.format(format);
+    }
     //----------------------------------------------------------
     //----------------------------------------------------------
   }


### PR DESCRIPTION
**In our application, timestamps (like created_at, updated_at, etc.) are stored in UTC format on the server. When a public URL is accessed from a browser in a different timezone, displaying this raw UTC time can lead to confusion for end users.

Why This Is Needed:

Without converting the time, users across different regions will always see UTC time, which does not reflect their local time. This can cause misunderstandings about event times, deadlines, or logs.
Solution:

We use a JavaScript-based client-side conversion function that automatically detects the user’s local timezone and converts the UTC timestamp into a human-readable format based on their system's time settings.

This ensures:
Accurate time representation across all geographies.
Better user experience, especially for time-sensitive information.
Elimination of timezone ambiguity for public-facing pages.

Example:

A UTC time 2025-04-21 12:18:02 will appear as:
21 April, 2025 05:48 PM (Asia/Kolkata) in India
21 April, 2025 08:18 AM (America/New_York) in the US**